### PR TITLE
fix removal of style; simplify font tags cleanup

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -45,9 +45,9 @@
     <strong id="bookmarklet">
       <a href="javascript:document.body.removeAttribute('background');
         for(ss of document.styleSheets){void(ss.disabled=true)}
-        for(el of document.getElementsByTagName('*')){void(el.style.cssText='');void(el.removeAttribute('bgColor'));}
-        for(t of document.getElementsByTagName('table')){t.border=0}
-        for(f of document.getElementsByTagName('font')){f.removeAttribute('size');f.removeAttribute('face');f.removeAttribute('color')}
+        for(el of document.getElementsByTagName('*')){void(el.removeAttribute('style'));void(el.removeAttribute('bgColor'));}
+        for(tb of document.getElementsByTagName('table')){tb.border=0}
+        for(ft of document.getElementsByTagName('font')){for(at of ft.attributes){ft.removeAttribute(at.name);}}
         document.head.insertAdjacentHTML('beforeend',
           '&lt;link rel=&quot;stylesheet&quot; href=&quot;'+
             (window.location.protocol.startsWith('http')?window.location.protocol:'http:')+


### PR DESCRIPTION
- Attempting to access properties of the style attribute
  didn't work for elements created dynamically,
  which had no style tag. For instance, the `<math>` tags in
  http://www.hedonisticlearning.com/posts/category-theory-syntactically.html
- Use two-letter variable names, for consistency and slightly improved readability
- simplify cleanup of font tags, thanks to http://stackoverflow.com/a/27664638